### PR TITLE
Install specific setuptools version to keep pkg_ressources

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -23,7 +23,7 @@ chown -R $app:www-data "$install_dir"
 pushd $install_dir
 	ynh_exec_as_app python3 -m venv $install_dir/venv
 	ynh_exec_as_app "$install_dir/venv/bin/pip" install --upgrade pip
-	ynh_exec_as_app "$install_dir/venv/bin/pip" install "setuptools<81"
+	ynh_exec_as_app "$install_dir/venv/bin/pip" install setuptools==80
 	ynh_exec_as_app "$install_dir/venv/bin/pip" install --upgrade MarkupSafe
 	ynh_exec_as_app "$install_dir/venv/bin/pip" install isso gunicorn
 popd

--- a/scripts/install
+++ b/scripts/install
@@ -23,7 +23,7 @@ chown -R $app:www-data "$install_dir"
 pushd $install_dir
 	ynh_exec_as_app python3 -m venv $install_dir/venv
 	ynh_exec_as_app "$install_dir/venv/bin/pip" install --upgrade pip
-	ynh_exec_as_app "$install_dir/venv/bin/pip" install --upgrade setuptools
+	ynh_exec_as_app "$install_dir/venv/bin/pip" install "setuptools<81"
 	ynh_exec_as_app "$install_dir/venv/bin/pip" install --upgrade MarkupSafe
 	ynh_exec_as_app "$install_dir/venv/bin/pip" install isso gunicorn
 popd


### PR DESCRIPTION
Change setuptools installation to restrict version to include pkg_ressources

## Problem

After setup, Isso service cannot to start due to missing package `pkg_resources`

` File "/var/www/isso/venv/lib/python3.11/site-packages/isso/__init__.py", line 28, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
`
see (https://ci-apps.yunohost.org/ci/job/28137) for more details
## Solution

- as describe in isso github repository (https://github.com/isso-comments/isso), it's necessary to install older version of setuptools < 81 (https://github.com/isso-comments/isso/issues/1063#issuecomment-3940687844)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
